### PR TITLE
TE-133: Preload emoji found in delayed messages

### DIFF
--- a/modules/channel-web/assets/default-emulator.css
+++ b/modules/channel-web/assets/default-emulator.css
@@ -46,6 +46,12 @@
     outline: none !important;
   }
 
+  .emoji {
+    width: 1.3em;
+    height: 1.3em;
+    vertical-align: -0.3em;
+  }
+
   .hidden {
     visibility: hidden;
     height: 0;

--- a/modules/channel-web/assets/default.css
+++ b/modules/channel-web/assets/default.css
@@ -22,6 +22,12 @@ body {
   outline: none !important;
 }
 
+.emoji {
+  width: 1.3em;
+  height: 1.3em;
+  vertical-align: -0.3em;
+}
+
 .hidden {
   visibility: hidden;
   height: 0;
@@ -864,7 +870,6 @@ body {
   margin-right: auto;
   max-width: 50%;
 }
-}
 
 .bpw-botinfo-cover-picture {
   width: 100%;
@@ -1050,4 +1055,5 @@ body {
 
 .bpw-mobx-tools {
   visibility: hidden;
+}
 }

--- a/modules/channel-web/src/views/lite/components/Container.tsx
+++ b/modules/channel-web/src/views/lite/components/Container.tsx
@@ -13,11 +13,16 @@ import Header from './Header'
 import * as Keyboard from './Keyboard'
 import MessageList from './messages/MessageList'
 import OverridableComponent from './OverridableComponent'
+import PreloadEmoji from './PreloadEmoji'
 
 class Container extends React.Component<ContainerProps> {
   renderBody() {
     if (!this.props.isInitialized) {
-      return (<div className="bpw-msg-list-container bpw-msg-list-container-loading"><div className="bpw-msg-list-loading" /></div>)
+      return (
+        <div className="bpw-msg-list-container bpw-msg-list-container-loading">
+          <div className="bpw-msg-list-loading" />
+        </div>
+      )
     }
 
     if (this.props.isConversationsDisplayed) {
@@ -48,6 +53,7 @@ class Container extends React.Component<ContainerProps> {
 
     return (
       <React.Fragment>
+        <PreloadEmoji />
         <OverridableComponent name={'before_container'} original={null} />
         <div className={classNames} style={{ width: this.props.dimensions.layout }}>
           <Header />

--- a/modules/channel-web/src/views/lite/components/ConversationList.tsx
+++ b/modules/channel-web/src/views/lite/components/ConversationList.tsx
@@ -5,6 +5,7 @@ import { InjectedIntlProps, injectIntl } from 'react-intl'
 import Add from '../icons/Add'
 import { RootStore, StoreDef } from '../store'
 import { ConversationSummary } from '../typings'
+import PreloadEmoji from './PreloadEmoji'
 
 const ConversationListItem = injectIntl(({ conversation, onClick, hasFocus, intl }: ConversationListItemProps) => {
   const title =
@@ -105,6 +106,7 @@ class ConversationList extends React.Component<ConversationListProps> {
         >
           <Add width={15} height={15} />
         </button>
+        <PreloadEmoji />
       </div>
     )
   }

--- a/modules/channel-web/src/views/lite/components/ConversationList.tsx
+++ b/modules/channel-web/src/views/lite/components/ConversationList.tsx
@@ -5,7 +5,6 @@ import { InjectedIntlProps, injectIntl } from 'react-intl'
 import Add from '../icons/Add'
 import { RootStore, StoreDef } from '../store'
 import { ConversationSummary } from '../typings'
-import PreloadEmoji from './PreloadEmoji'
 
 const ConversationListItem = injectIntl(({ conversation, onClick, hasFocus, intl }: ConversationListItemProps) => {
   const title =
@@ -106,7 +105,6 @@ class ConversationList extends React.Component<ConversationListProps> {
         >
           <Add width={15} height={15} />
         </button>
-        <PreloadEmoji />
       </div>
     )
   }

--- a/modules/channel-web/src/views/lite/components/PreloadEmoji.tsx
+++ b/modules/channel-web/src/views/lite/components/PreloadEmoji.tsx
@@ -5,22 +5,27 @@ import { RootStore, StoreDef } from '../store'
 import { emojiRegex, getEmojiUrl } from '../utils'
 
 const PreloadEmoji = ({ delayedMessages }: PreloadEmojiProps) => {
-  useEffect(() => {
-    delayedMessages
-      .map(message => message.message.message_text)
-      .join('')
-      .match(emojiRegex)
-      .map(getEmojiUrl)
-      .forEach(url => {
-        new Image().src = url
-      })
-  }, [delayedMessages])
+  delayedMessages
+    ?.map(({ message }) => {
+      if (message.message_type === 'text') {
+        return message.message_text
+      }
+      if (message.message_type === 'custom') {
+        return message.payload?.wrapped?.text
+      }
+    })
+    .join('')
+    .match(emojiRegex)
+    ?.map(getEmojiUrl)
+    .forEach(url => {
+      new Image().src = url
+    })
 
   return null
 }
 
 export default inject(({ store }: { store: RootStore }) => ({
-  delayedMessages: store.delayedMessages,
+  delayedMessages: store.delayedMessages
 }))(observer(PreloadEmoji))
 
 type PreloadEmojiProps = Pick<StoreDef, 'delayedMessages'>

--- a/modules/channel-web/src/views/lite/components/PreloadEmoji.tsx
+++ b/modules/channel-web/src/views/lite/components/PreloadEmoji.tsx
@@ -1,0 +1,26 @@
+import { inject, observer } from 'mobx-react'
+import React, { useEffect } from 'react'
+
+import { RootStore, StoreDef } from '../store'
+import { emojiRegex, getEmojiUrl } from '../utils'
+
+const PreloadEmoji = ({ delayedMessages }: PreloadEmojiProps) => {
+  useEffect(() => {
+    delayedMessages
+      .map(message => message.message.message_text)
+      .join('')
+      .match(emojiRegex)
+      .map(getEmojiUrl)
+      .forEach(url => {
+        new Image().src = url
+      })
+  }, [delayedMessages])
+
+  return null
+}
+
+export default inject(({ store }: { store: RootStore }) => ({
+  delayedMessages: store.delayedMessages,
+}))(observer(PreloadEmoji))
+
+type PreloadEmojiProps = Pick<StoreDef, 'delayedMessages'>

--- a/modules/channel-web/src/views/lite/store/index.ts
+++ b/modules/channel-web/src/views/lite/store/index.ts
@@ -70,6 +70,7 @@ class RootStore {
   @observable
   public botUILanguage: string = chosenLocale
 
+  @observable
   public delayedMessages: QueuedMessage[] = []
 
   constructor({ fullscreen }) {

--- a/modules/channel-web/src/views/lite/utils.tsx
+++ b/modules/channel-web/src/views/lite/utils.tsx
@@ -2,7 +2,8 @@ import ReactGA from 'react-ga'
 import snarkdown from 'snarkdown'
 import emojiUnicode from 'emoji-unicode'
 import emojiRegexRGI from 'emoji-regex/RGI_Emoji'
-const emojiRegex = emojiRegexRGI()
+
+export const emojiRegex = emojiRegexRGI()
 
 export const getOverridedComponent = (overrides, componentName) => {
   if (overrides?.[componentName]) {
@@ -101,7 +102,7 @@ export const renderUnsafeHTML = (message: string = '', escaped: boolean): string
   return html.replace(/<a href/gi, '<a target="_blank" href')
 }
 
-export const renderEmoji = (emoji: string): string => {
+export const getEmojiUrl = (emoji: string): string => {
   const code = emojiUnicode(emoji)
     .split(' ')
     .map(code => code.padStart(4, '0'))
@@ -109,5 +110,10 @@ export const renderEmoji = (emoji: string): string => {
     .filter(code => code !== '200d')
     .join('-')
 
-  return `<img src="https://f4s-production-uploads.s3-ap-southeast-2.amazonaws.com/emoji/${code}.svg" alt="${emoji}" draggable="false" class="emoji"/>`
+  return `https://f4s-production-uploads.s3-ap-southeast-2.amazonaws.com/emoji/${code}.svg`
+}
+
+export const renderEmoji = (emoji: string): string => {
+  const url = getEmojiUrl(emoji)
+  return `<img src="${url}" alt="${emoji}" draggable="false" class="emoji"/>`
 }


### PR DESCRIPTION
This change adds a PreloadEmoji component which scans messages ahead of time and preloads any emoji images within them.
Extra handling was required for custom messages, ( QuickReplies ) as the message content is wrapped / contained differently. 

Also fixes the size of emojis in the emulator:
![image](https://user-images.githubusercontent.com/78133938/116340938-5b0f8e80-a823-11eb-8641-50b5eef97c08.png)