### PR TITLE
CM-502: Disable responsiveness for carousels

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/renderer/Carousel.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/Carousel.tsx
@@ -27,13 +27,14 @@ export class Carousel extends React.Component<ICarouselProps, ICarouselState> {
     const defaultSettings = {
       dots: false,
       infinite: false,
-      responsive: [
-        { breakpoint: adjustBreakpoint(550), settings: { slidesToShow: 1 } },
-        { breakpoint: adjustBreakpoint(1024), settings: { slidesToShow: 2 } },
-        { breakpoint: adjustBreakpoint(1548), settings: { slidesToShow: 3 } },
-        { breakpoint: adjustBreakpoint(2072), settings: { slidesToShow: 4 } },
-        { breakpoint: adjustBreakpoint(10000), settings: 'unslick' }
-      ],
+      // Disable responsiveness as chat window width is fixed
+      // responsive: [
+      //   { breakpoint: adjustBreakpoint(550), settings: { slidesToShow: 1 } },
+      //   { breakpoint: adjustBreakpoint(1024), settings: { slidesToShow: 2 } },
+      //   { breakpoint: adjustBreakpoint(1548), settings: { slidesToShow: 3 } },
+      //   { breakpoint: adjustBreakpoint(2072), settings: { slidesToShow: 4 } },
+      //   { breakpoint: adjustBreakpoint(10000), settings: 'unslick' }
+      // ],
       slidesToScroll: 1,
       autoplay: false,
       centerMode: false,


### PR DESCRIPTION
This fix disables responsiveness for carousels on larger screen sizes.

Before:
> Carousel trying to display 2 slides on a 1080p display
![image](https://user-images.githubusercontent.com/78133938/123356618-5f4df300-d5ab-11eb-9990-b0cb97a5e9d6.png)

Currently, the carousel will add increasing amounts of grey padding the wider the screen gets, and on 4k screens, the carousel will disappear altogether. 

Since the chat window has a max-width, this responsiveness is not required, and carousels look fine taking up the full width.

Note: This has not been tested locally, however, it should be non-breaking.